### PR TITLE
[Feature] 네이버 로그인 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,18 +22,23 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        // local.properties에서 카카오 앱 키 읽기
+        // local.properties
         val properties = Properties()
         val localPropertiesFile = rootProject.file("local.properties")
         if (localPropertiesFile.exists()) {
             properties.load(FileInputStream(localPropertiesFile))
         }
 
-        val kakaoKey = properties.getProperty("KAKAO_NATIVE_APP_KEY")
-            ?: "8367190c9f93267d9fb62bc7a6cbc6cb"
+        val kakaoKey = properties.getProperty("KAKAO_NATIVE_APP_KEY") ?: ""
+        val naverClientId = properties.getProperty("NAVER_CLIENT_ID") ?: ""
+        val naverClientSecret = properties.getProperty("NAVER_CLIENT_SECRET") ?: ""
 
         buildConfigField("String", "KAKAO_NATIVE_APP_KEY", "\"$kakaoKey\"")
+        buildConfigField("String", "NAVER_CLIENT_ID", "\"$naverClientId\"")
+        buildConfigField("String", "NAVER_CLIENT_SECRET", "\"$naverClientSecret\"")
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] = kakaoKey
+        manifestPlaceholders["NAVER_CLIENT_ID"] = naverClientId
+        manifestPlaceholders["NAVER_CLIENT_SECRET"] = naverClientSecret
     }
 
     buildTypes {

--- a/app/src/main/java/com/example/momenty/MomentyApplication.kt
+++ b/app/src/main/java/com/example/momenty/MomentyApplication.kt
@@ -28,6 +28,8 @@ class MomentyApplication : Application() {
         if (BuildConfig.DEBUG) {
             val keyHash = Utility.getKeyHash(this)
             Log.d("KAKAO_KEY_HASH", "Key Hash: $keyHash")
+            Log.d("NAVER_CHECK", "ID='${BuildConfig.NAVER_CLIENT_ID}'")
+            Log.d("NAVER_CHECK", "SECRET='${BuildConfig.NAVER_CLIENT_SECRET}'")
         }
     }
 }

--- a/app/src/main/java/com/example/momenty/MomentyApplication.kt
+++ b/app/src/main/java/com/example/momenty/MomentyApplication.kt
@@ -3,6 +3,7 @@ package com.example.momenty
 import android.app.Application
 import android.util.Log
 import com.kakao.sdk.common.KakaoSdk
+import com.navercorp.nid.NaverIdLoginSDK
 import com.kakao.sdk.common.util.Utility
 import dagger.hilt.android.HiltAndroidApp
 
@@ -16,7 +17,12 @@ class MomentyApplication : Application() {
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
 
         //네아버 SDK 초기화
-
+        NaverIdLoginSDK.initialize(
+            context = this,
+            clientId = BuildConfig.NAVER_CLIENT_ID,
+            clientSecret = BuildConfig.NAVER_CLIENT_SECRET,
+            clientName = getString(R.string.app_name)
+        )
 
         // 디버그 모드에서만 키 해시 출력
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/example/momenty/data/remote/auth/AuthApi.kt
+++ b/app/src/main/java/com/example/momenty/data/remote/auth/AuthApi.kt
@@ -15,6 +15,11 @@ interface AuthApi {
     suspend fun googleLogin(
         @Body request: GoogleLoginRequest
     ): BaseResponse<LoginResponse>
+
+    @POST("auth/naver/login")
+    suspend fun naverLogin(
+        @Body request: NaverLoginRequest
+    ): BaseResponse<LoginResponse>
 }
 
 data class LoginResponse(

--- a/app/src/main/java/com/example/momenty/data/remote/auth/NaverLoginRequest.kt
+++ b/app/src/main/java/com/example/momenty/data/remote/auth/NaverLoginRequest.kt
@@ -1,0 +1,5 @@
+package com.example.momenty.data.remote.auth
+// ===== Request 모델 =====
+data class NaverLoginRequest(
+    val accessToken: String
+)

--- a/app/src/main/java/com/example/momenty/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/momenty/data/repository/AuthRepository.kt
@@ -9,6 +9,7 @@ import com.example.momenty.data.remote.auth.AuthApi
 import com.example.momenty.data.remote.auth.GoogleLoginRequest
 import com.example.momenty.data.remote.auth.KakaoLoginRequest
 import com.example.momenty.data.remote.auth.LoginResponse
+import com.example.momenty.data.remote.auth.NaverLoginRequest
 import com.example.momenty.global.api.ApiException
 import com.example.momenty.global.api.BaseResponse
 import com.example.momenty.global.security.TokenManager
@@ -24,6 +25,9 @@ import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import com.navercorp.nid.NaverIdLoginSDK
+import com.navercorp.nid.oauth.NidOAuthLogin
+import com.navercorp.nid.oauth.OAuthLoginCallback
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeout
@@ -48,6 +52,14 @@ sealed class AuthResult {
         data class Unknown(override val message: String, val throwable: Throwable? = null) : Error(message)
     }
 }
+
+/**
+ * 네이버 토큰 정보
+ */
+data class NaverToken(
+    val accessToken: String,
+    val tokenType: String
+)
 
 /**
  * 인증 관련 Repository
@@ -173,6 +185,34 @@ class AuthRepository @Inject constructor(
             }
         } catch (e: Exception) {
             handleLoginError("Kakao", e)
+        }
+    }
+
+    /**
+     * 네이버 로그인 (카카오와 동일한 방법)
+     */
+    suspend fun loginWithNaver(): AuthResult {
+        return try{
+            withTimeout(LOGIN_TIMEOUT_MS){
+                logLoginAttempt("Naver", null)
+
+                val naverToken = getNaverAccessToken()
+                Log.d(TAG, "네이버 토큰 획득 성공")
+
+                if(USE_MOCK){
+                    return@withTimeout loginWithFirebaseMock()
+                }
+
+                executeLoginFlow(
+                    getIdToken = {naverToken.accessToken},
+                    loginRequest = {accessToken ->
+                        authApi.naverLogin(NaverLoginRequest(accessToken))
+                    },
+                    mockLogin = { loginWithFirebaseMock() }
+                )
+            }
+        } catch (e: Exception) {
+            handleLoginError("Naver", e)
         }
     }
 
@@ -326,6 +366,18 @@ class AuthRepository @Inject constructor(
     }
 
     /**
+     * 네이버 Access Token 가져오기
+     */
+    private fun getNaverAccessToken(): NaverToken {
+        val accessToken = NaverIdLoginSDK.getAccessToken()
+            ?: throw IllegalStateException("네이버 액세스 토큰을 가져올 수 없습니다.")
+
+        val tokenType = NaverIdLoginSDK.getTokenType() ?: "Bearer"
+
+        return NaverToken(accessToken, tokenType)
+    }
+
+    /**
      * Firebase Custom Token으로 로그인
      */
     private suspend fun signInWithFirebaseCustomToken(customToken: String): FirebaseUser {
@@ -399,7 +451,16 @@ class AuthRepository @Inject constructor(
                 errors.add(it)
             }
 
-            // 3. 토큰 정리 및 Firebase 로그아웃 (항상 실행)
+            // 3. 네이버 로그아웃
+            runCatching {
+                NaverIdLoginSDK.logout()
+                Log.d(TAG, "네이버 로그아웃 성공")
+            }.onFailure {
+                Log.e(TAG, "네이버 로그아웃 실패", it)
+                errors.add(it)
+            }
+
+            // 4. 토큰 정리 및 Firebase 로그아웃 (항상 실행)
             tokenManager.clearTokens()
             firebaseAuth.signOut()
 
@@ -469,7 +530,36 @@ class AuthRepository @Inject constructor(
                 errors.add(it)
             }
 
-            // 4. 토큰 정리 (항상 실행)
+            // 4. 네이버 연결 끊기
+            runCatching {
+                suspendCoroutine<Unit> { continuation ->
+                    NidOAuthLogin().callDeleteTokenApi(object : OAuthLoginCallback {
+                        override fun onSuccess() {
+                            Log.d(TAG, "네이버 연결 끊기 성공")
+                            continuation.resume(Unit)
+                        }
+
+                        override fun onFailure(httpStatus: Int, message: String) {
+                            val error = Exception("네이버 연결 끊기 실패: $message")
+                            Log.e(TAG, error.message, error)
+                            errors.add(error)
+                            continuation.resume(Unit)
+                        }
+
+                        override fun onError(errorCode: Int, message: String) {
+                            val error = Exception("네이버 연결 끊기 오류: $message")
+                            Log.e(TAG, error.message, error)
+                            errors.add(error)
+                            continuation.resume(Unit)
+                        }
+                    })
+                }
+            }.onFailure {
+                Log.e(TAG, "네이버 연결 끊기 처리 중 오류", it)
+                errors.add(it)
+            }
+
+            // 5. 토큰 정리 (항상 실행)
             tokenManager.clearTokens()
 
             if (errors.isNotEmpty()) {

--- a/app/src/main/java/com/example/momenty/domain/member/presentation/AuthViewModel.kt
+++ b/app/src/main/java/com/example/momenty/domain/member/presentation/AuthViewModel.kt
@@ -1,12 +1,14 @@
-// ui/auth/AuthViewModel.kt
 package com.example.momenty.ui.auth
 
+import android.content.Context
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.momenty.data.repository.AuthRepository
 import com.example.momenty.data.repository.AuthResult
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.navercorp.nid.NaverIdLoginSDK
+import com.navercorp.nid.oauth.OAuthLoginCallback
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -71,6 +73,42 @@ class AuthViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * 네이버 로그인
+     */
+    fun loginWithNaver(context: Context) {
+        _uiState.value = AuthUiState.Loading
+
+        val oAuthLoginCallback = object : OAuthLoginCallback {
+            override fun onSuccess() {
+                // 로그인 성공 -> 액세스 토큰으로 사용자 정보 가져옴
+                viewModelScope.launch {
+                    when(val result = authRepository.loginWithNaver()){
+                        is AuthResult.Success -> {
+                            _uiState.value = AuthUiState.Success(result.user.displayName)
+                        }
+                        is AuthResult.Error -> {
+                            _uiState.value = AuthUiState.Error(getErrorMessage(result))
+                        }
+                    }
+                }
+            }
+
+            override fun onFailure(httpStatus: Int, message: String) {
+                _uiState.value = AuthUiState.Error("네이버 로그인 실패: $message")
+            }
+
+            override fun onError(errorCode: Int, message: String) {
+                _uiState.value = when(errorCode){
+                    -1 -> AuthUiState.Error("로그인이 취소되었습니다.")
+                    else -> AuthUiState.Error("네이버 로그인 오류: $message")
+                }
+            }
+        }
+
+        NaverIdLoginSDK.authenticate(context, oAuthLoginCallback)
     }
 
     fun resetState() {

--- a/app/src/main/java/com/example/momenty/domain/member/presentation/LoginPage3Fragment.kt
+++ b/app/src/main/java/com/example/momenty/domain/member/presentation/LoginPage3Fragment.kt
@@ -79,7 +79,10 @@ class LoginPage3Fragment : Fragment() {
             authViewModel.startGoogleSignIn(googleSignInLauncher)
         }
 
-        binding.btnNaverLogin.setOnClickListener {}
+        // 네이버 로그인
+        binding.btnNaverLogin.setOnClickListener {
+            authViewModel.loginWithNaver(requireContext())
+        }
     }
 
     private fun observeLoginState() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 관련된 이슈 번호를 적어주세요.
 - Closes #23 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [ O ] 네이버 SDK 연결
- [ O ] 네이버 개발자 센터에 어플리케이션 등록 후 client id & client secret 발급
- [ O ] 카카오 로그인과 동일한 방식으로 네이버 로그인 구현 완료

- [ ] TODO : 백엔드와 엔드포인트 통일, 전달 방식 통일하여 수정 (현재 확인 중에 있음)
- [ ] TODO : 네이버 개발자 센터에 팀원들 초대 (client id와 client secret은 모두 동일하게 사용 & 각자 local에 등록)

## 💬작업 중 발생한 이슈

> 개발 중 발생한 이슈와 어떻게 해결했는지 간략히 설명해주세요

네이버 client id, client secret을 읽어오지 못함 -> localproperties에서 변수명 변경 후 해결
- naver.client.id -> NAVER_CLIENT_ID

## #️⃣스크린샷 (선택)

> UI 변경 사항이 있다면 스크린샷을 첨부해주세요.
<img width="641" height="1369" alt="스크린샷 2026-02-04 035217" src="https://github.com/user-attachments/assets/497aaffc-e529-4237-88c4-6bd0fa28bbf5" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요
