### PR TITLE
[Feat] 모먼티 기록 api연결

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-02-14T23:37:46.320763300Z">
+        <DropdownSelection timestamp="2026-02-15T08:27:46.962855400Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Administrator\.android\avd\Pixel_8.avd" />

--- a/app/src/main/java/com/example/momenty/data/remote/S3Uploader.kt
+++ b/app/src/main/java/com/example/momenty/data/remote/S3Uploader.kt
@@ -1,0 +1,26 @@
+package com.example.momenty.data.remote
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+object S3Uploader {
+    private val client = OkHttpClient()
+
+    fun upload(presignedUrl: String, bytes: ByteArray, contentType: String) {
+        val body = bytes.toRequestBody(contentType.toMediaType())
+
+        val request = Request.Builder()
+            .url(presignedUrl)
+            .put(body)
+            .addHeader("Content-Type", contentType)
+            .build()
+
+        client.newCall(request).execute().use { res ->
+            if (!res.isSuccessful) {
+                throw IllegalStateException("S3 업로드 실패 code=${res.code}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/momenty/data/remote/moment/MomentListResultDto.kt
+++ b/app/src/main/java/com/example/momenty/data/remote/moment/MomentListResultDto.kt
@@ -58,4 +58,9 @@ data class MomentImageKeyDto(
 
 enum class ImageTypeDto { JPEG, PNG }
 
+data class MomentDetailResultDto(
+    val images: List<MomentImageKeyDto>,
+    val emotion: EmotionDto,
+    val content: String
+)
 

--- a/app/src/main/java/com/example/momenty/data/remote/moment/MomentListResultDto.kt
+++ b/app/src/main/java/com/example/momenty/data/remote/moment/MomentListResultDto.kt
@@ -1,0 +1,61 @@
+package com.example.momenty.data.remote.moment
+
+import com.google.gson.annotations.SerializedName
+
+data class MomentListResultDto(
+    @SerializedName("moments")
+    val moments: List<MomentItemDto>,
+    @SerializedName("pageInfo")
+    val pageInfo: PageInfoDto,
+)
+
+data class MomentItemDto(
+    @SerializedName("momentId") val momentId: Long,
+    @SerializedName("emotion") val emotion: EmotionDto,
+    @SerializedName("createdAt") val createdAt: String,
+    @SerializedName("content") val content: String,
+    @SerializedName("imageUrl") val imageUrl: String? = null
+)
+
+
+
+enum class EmotionDto {
+    HAPPINESS,
+    SADNESS,
+    NEUTRAL
+}
+
+data class PageInfoDto(
+    @SerializedName("page")
+    val page: Int,
+    @SerializedName("size")
+    val size: Int,
+    @SerializedName("totalPages")
+    val totalPages: Int,
+    @SerializedName("totalElements")
+    val totalElements: Long,
+    @SerializedName("hasNext")
+    val hasNext: Boolean,
+    @SerializedName("hasPrevious")
+    val hasPrevious: Boolean,
+)
+
+data class PresignedRequestDto(
+    val imageTypes: List<String>
+)
+
+data class PresignedUrlDto(val key: String, val url: String)
+
+data class CreateMomentRequestDto(
+    val images: List<MomentImageKeyDto>,
+    val emotion: EmotionDto,
+    val content: String,
+)
+
+data class MomentImageKeyDto(
+    val imageKey: String
+)
+
+enum class ImageTypeDto { JPEG, PNG }
+
+

--- a/app/src/main/java/com/example/momenty/data/remote/moment/MomentsApi.kt
+++ b/app/src/main/java/com/example/momenty/data/remote/moment/MomentsApi.kt
@@ -34,4 +34,12 @@ interface MomentsApi {
     ): BaseResponse<String>
 
 
+    @GET("/api/moments/users/{userId}/pets/{petId}/{momentId}")
+    suspend fun getMomentDetail(
+        @Path("userId") userId: Long,
+        @Path("petId") petId: Long,
+        @Path("momentId") momentId: Long
+    ): BaseResponse<MomentDetailResultDto>
+
+
 }

--- a/app/src/main/java/com/example/momenty/data/remote/moment/MomentsApi.kt
+++ b/app/src/main/java/com/example/momenty/data/remote/moment/MomentsApi.kt
@@ -1,0 +1,37 @@
+package com.example.momenty.data.remote.moment
+
+import com.example.momenty.global.api.BaseResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface MomentsApi {
+
+    // 게시글 조희
+    @GET("/api/moments/users/{userId}/pets/{petId}")
+    suspend fun getMomentsByPet(
+        @Path("userId") userId: Long,
+        @Path("petId") petId: Long,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 10,
+        @Query("sort") sort: List<String> = listOf("createdAt,DESC"),
+    ): BaseResponse<MomentListResultDto>
+
+    // presigned 발급
+    @POST("/api/moments/image")
+    suspend fun createMomentImagePresignedUrl(
+        @Body body: PresignedRequestDto
+    ): BaseResponse<List<PresignedUrlDto>>
+
+    // 모먼트 생성
+    @POST("/api/moments/users/{userId}/pets/{petId}")
+    suspend fun createMoment(
+        @Path("userId") userId: Long,
+        @Path("petId") petId: Long,
+        @Body body: CreateMomentRequestDto
+    ): BaseResponse<String>
+
+
+}

--- a/app/src/main/java/com/example/momenty/data/repository/MomentRepository.kt
+++ b/app/src/main/java/com/example/momenty/data/repository/MomentRepository.kt
@@ -6,6 +6,7 @@ import com.example.momenty.data.remote.S3Uploader
 import com.example.momenty.data.remote.moment.CreateMomentRequestDto
 import com.example.momenty.data.remote.moment.EmotionDto
 import com.example.momenty.data.remote.moment.ImageTypeDto
+import com.example.momenty.data.remote.moment.MomentDetailResultDto
 import com.example.momenty.data.remote.moment.MomentImageKeyDto
 import com.example.momenty.data.remote.moment.MomentListResultDto
 import com.example.momenty.data.remote.moment.MomentsApi
@@ -101,6 +102,15 @@ class MomentRepository @Inject constructor(
         )
 
         return momentsApi.createMoment(userId, petId, body)
+    }
+
+
+    suspend fun getMomentDetail(
+        userId: Long,
+        petId: Long,
+        momentId: Long
+    ): BaseResponse<MomentDetailResultDto> {
+        return momentsApi.getMomentDetail(userId, petId, momentId)
     }
 
 

--- a/app/src/main/java/com/example/momenty/data/repository/MomentRepository.kt
+++ b/app/src/main/java/com/example/momenty/data/repository/MomentRepository.kt
@@ -1,0 +1,107 @@
+package com.example.momenty.data.repository
+
+import android.content.ContentResolver
+import android.net.Uri
+import com.example.momenty.data.remote.S3Uploader
+import com.example.momenty.data.remote.moment.CreateMomentRequestDto
+import com.example.momenty.data.remote.moment.EmotionDto
+import com.example.momenty.data.remote.moment.ImageTypeDto
+import com.example.momenty.data.remote.moment.MomentImageKeyDto
+import com.example.momenty.data.remote.moment.MomentListResultDto
+import com.example.momenty.data.remote.moment.MomentsApi
+import com.example.momenty.data.remote.moment.PresignedRequestDto
+import com.example.momenty.global.api.BaseResponse
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class MomentRepository @Inject constructor(
+    private val momentsApi: MomentsApi,
+) {
+    suspend fun getMomentList(
+        userId: Long,
+        petId: Long,
+        page: Int = 0,
+        size: Int = 10,
+    ): BaseResponse<MomentListResultDto> {
+        return momentsApi.getMomentsByPet(
+            userId = userId,
+            petId = petId,
+            page = page,
+            size = size,
+            sort = listOf("createdAt,DESC")
+        )
+    }
+
+    suspend fun createMomentWithImages(
+        userId: Long,
+        petId: Long,
+        emotion: EmotionDto,
+        content: String,
+        imageUris: List<Uri>,
+        contentResolver: ContentResolver
+    ): BaseResponse<String> {
+
+        if (imageUris.isEmpty()) throw IllegalArgumentException("사진 1장 이상 필요")
+
+        val safeUris = imageUris.take(5)
+        val imageCount = safeUris.size
+
+
+        val mimeTypes = safeUris.map { uri ->
+            contentResolver.getType(uri) ?: "image/jpeg"
+        }
+
+
+        val imageTypes = mimeTypes.map { mime ->
+            if (mime == "image/png") "PNG" else "JPEG"
+        }
+
+        val presignedRes =
+            momentsApi.createMomentImagePresignedUrl(
+                PresignedRequestDto(imageTypes)
+            )
+
+
+        val presignedAll = presignedRes.result.orEmpty()
+        val presigned = presignedAll.take(imageCount)
+
+        if (!presignedRes.isSuccess || presigned.size != imageCount) {
+            throw IllegalStateException("presigned 발급 실패 or 개수 불일치")
+        }
+
+
+
+        if (!com.example.momenty.global.mock.MockApiInterceptor.isMockEnabled) {
+            presigned.forEachIndexed { idx, item ->
+                val uri = safeUris[idx]
+                val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                    ?: throw IllegalStateException("이미지 읽기 실패: $uri")
+
+                val contentType = mimeTypes[idx]
+
+                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                    com.example.momenty.data.remote.S3Uploader.upload(
+                        presignedUrl = item.url,
+                        bytes = bytes,
+                        contentType = contentType
+                    )
+                }
+            }
+        } else {
+            android.util.Log.d("MockApi", "SKIP S3 upload (mock mode)")
+        }
+
+
+        // 4) 모먼트 생성
+        val body = CreateMomentRequestDto(
+            images = presigned.map { MomentImageKeyDto(it.key) },
+            emotion = emotion,
+            content = content
+        )
+
+        return momentsApi.createMoment(userId, petId, body)
+    }
+
+
+}

--- a/app/src/main/java/com/example/momenty/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/momenty/di/NetworkModule.kt
@@ -1,10 +1,11 @@
 package com.example.momenty.di
 
 import com.example.momenty.data.remote.auth.AuthApi
+import com.example.momenty.data.remote.moment.MomentsApi
 import com.example.momenty.data.remote.profile.ProfileApi
 import com.example.momenty.global.mock.MockApiInterceptor
 import com.example.momenty.global.security.AuthInterceptor
-import com.kakao.sdk.v2.auth.BuildConfig
+import com.example.momenty.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -79,6 +80,15 @@ object NetworkModule {
     fun provideProfileApi(retrofit: Retrofit): ProfileApi =
         retrofit.create(ProfileApi::class.java)
 
-    fun getRetrofit(okHttpClient: OkHttpClient): Retrofit = provideRetrofit(okHttpClient)
+    fun getRetrofit(): Retrofit {
+        val retrofit = Retrofit.Builder().baseUrl(BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create()).build()
+        return retrofit
+    }
+
+    @Provides
+    @Singleton
+    fun provideMomentsApi(retrofit: Retrofit): MomentsApi =
+        retrofit.create(MomentsApi::class.java)
 
 }

--- a/app/src/main/java/com/example/momenty/domain/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/momenty/domain/home/HomeFragment.kt
@@ -36,14 +36,17 @@ class HomeFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        //return inflater.inflate(R.layout.fragment_home, container, false)
+    ): View {
         binding = FragmentHomeBinding.inflate(inflater, container, false)
-//        G
+
+        binding.tvHome.setOnClickListener {
+            val intent = Intent(requireActivity(), QuestActivity::class.java)
+            startActivity(intent)
+        }
 
         return binding.root
     }
+
 
     companion object {
         /**

--- a/app/src/main/java/com/example/momenty/domain/record/RecordAdapter.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/RecordAdapter.kt
@@ -6,9 +6,15 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.momenty.databinding.ItemRecordBinding
 import com.example.momenty.domain.record.write.RecordItem
 
-class RecordAdapter(
-    private val items: List<RecordItem>
-) : RecyclerView.Adapter<RecordAdapter.RecordViewHolder>() {
+class RecordAdapter : RecyclerView.Adapter<RecordAdapter.RecordViewHolder>() {
+
+    private val items = mutableListOf<RecordItem>()
+
+    fun submitList(newItems: List<RecordItem>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
+    }
 
     inner class RecordViewHolder(
         private val binding: ItemRecordBinding
@@ -19,11 +25,9 @@ class RecordAdapter(
             binding.tvMoodChip.text = item.mood
             binding.tvContent.text = item.content
             binding.tvMoodText.text = item.title
-            binding.ivThumb.setImageResource(item.imageRes)
+            binding.ivThumb.setImageResource(item.imageRes) // 지금은 placeholder
         }
-
     }
-
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecordViewHolder {
         val binding = ItemRecordBinding.inflate(

--- a/app/src/main/java/com/example/momenty/domain/record/RecordAdapter.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/RecordAdapter.kt
@@ -6,7 +6,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.momenty.databinding.ItemRecordBinding
 import com.example.momenty.domain.record.write.RecordItem
 
-class RecordAdapter : RecyclerView.Adapter<RecordAdapter.RecordViewHolder>() {
+class RecordAdapter(
+    private val onClick: (RecordItem) -> Unit
+) : RecyclerView.Adapter<RecordAdapter.RecordViewHolder>() {
 
     private val items = mutableListOf<RecordItem>()
 
@@ -26,6 +28,7 @@ class RecordAdapter : RecyclerView.Adapter<RecordAdapter.RecordViewHolder>() {
             binding.tvContent.text = item.content
             binding.tvMoodText.text = item.title
             binding.ivThumb.setImageResource(item.imageRes) // 지금은 placeholder
+            binding.root.setOnClickListener { onClick(item) }
         }
     }
 

--- a/app/src/main/java/com/example/momenty/domain/record/RecordFragment.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/RecordFragment.kt
@@ -38,7 +38,17 @@ class RecordFragment : Fragment(R.layout.fragment_record) {
             findNavController().navigate(R.id.action_global_to_community)
         }
 
-        val adapter = RecordAdapter()
+        val adapter = RecordAdapter { item ->
+            val action = RecordFragmentDirections.actionRecordToMomentDetail(
+                userId = 1L,
+                petId = 1L,
+                momentId = item.momentId,
+                createdAt = item.createdAtRaw
+            )
+            findNavController().navigate(action)
+        }
+
+
         binding.rvRecord.layoutManager = LinearLayoutManager(requireContext())
         binding.rvRecord.adapter = adapter
 

--- a/app/src/main/java/com/example/momenty/domain/record/RecordFragment.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/RecordFragment.kt
@@ -7,84 +7,61 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.momenty.R
 import com.example.momenty.databinding.FragmentRecordBinding
-import com.example.momenty.domain.record.write.RecordItem
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class RecordFragment : Fragment(R.layout.fragment_record) {
+
+    private val viewModel: RecordViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentRecordBinding.bind(view)
 
-
-        val dummyList = listOf(
-            RecordItem(
-                "2025.11.21",
-                "즐거운 날",
-                "즐거움",
-                "오늘은 특별한 날이었어요!",
-                R.drawable.dummy1
-            ),
-            RecordItem(
-                "2025.10.31",
-                "슬픔",
-                "우울한 하루였어요",
-                "내용 작성~~~",
-                R.drawable.dummy2
-            ),
-            RecordItem(
-                "2025.09.15",
-                "보통",
-                "그냥 그런 하루",
-                "오늘은 평범했어요",
-                R.drawable.dummy3
-            )
-        )
-
-
         WindowCompat.setDecorFitsSystemWindows(requireActivity().window, false)
-
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
             val top = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
             binding.topBar.updatePadding(top = top)
-
-
             insets
         }
-
         ViewCompat.requestApplyInsets(binding.root)
-
-
-
-
-
 
         binding.btnGoCommunity.setOnClickListener {
             findNavController().navigate(R.id.action_global_to_community)
+        }
 
+        val adapter = RecordAdapter()
+        binding.rvRecord.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvRecord.adapter = adapter
+
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.items.collect { list ->
+                adapter.submitList(list)
+            }
         }
 
 
-        binding.rvRecord.layoutManager = LinearLayoutManager(requireContext())
-        binding.rvRecord.adapter = RecordAdapter(dummyList)
+        val userId = 1L
+        val petId = 1L
+        viewModel.loadMoments(userId, petId)
 
         binding.btnRecordCreate.setOnClickListener {
             findNavController().navigate(R.id.action_record_to_write)
         }
-
         binding.btnRecordMonth.setOnClickListener {
             findNavController().navigate(R.id.action_record_to_album)
         }
-
         binding.btnRecordStatistics.setOnClickListener {
             findNavController().navigate(R.id.action_record_to_recordStats)
         }
-
-
-
     }
 }

--- a/app/src/main/java/com/example/momenty/domain/record/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/RecordViewModel.kt
@@ -31,12 +31,15 @@ class RecordViewModel @Inject constructor(
             }.onSuccess { res ->
                 val mapped = res.result?.moments?.map { dto ->
                     RecordItem(
+                        momentId = dto.momentId.toLong(),
                         date = dto.createdAt.toKoreanDateOrFallback(),
                         title = dto.emotion.toTitle(),
                         mood = dto.emotion.toChip(),
+                        createdAtRaw = dto.createdAt,
                         content = dto.content,
-                        imageRes = R.drawable.dummy1 //일단은 서버에서 안내오고 있어서 밴드 붙였습니다
+                        imageRes = R.drawable.dummy1 // 응급처치
                     )
+
                 }
 
                 _items.value = if (res.isSuccess && mapped != null) mapped else emptyList()

--- a/app/src/main/java/com/example/momenty/domain/record/RecordViewModel.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/RecordViewModel.kt
@@ -1,0 +1,100 @@
+package com.example.momenty.domain.record
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.momenty.R
+import com.example.momenty.data.remote.moment.EmotionDto
+import com.example.momenty.data.repository.MomentRepository
+import com.example.momenty.domain.record.write.RecordItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+
+@HiltViewModel
+class RecordViewModel @Inject constructor(
+    private val momentRepository: MomentRepository
+) : ViewModel() {
+
+
+
+    private val _items = MutableStateFlow<List<RecordItem>>(emptyList())
+    val items: StateFlow<List<RecordItem>> = _items
+
+    fun loadMoments(userId: Long, petId: Long) {
+        viewModelScope.launch {
+            runCatching {
+                momentRepository.getMomentList(userId = userId, petId = petId, page = 0, size = 20)
+            }.onSuccess { res ->
+                val mapped = res.result?.moments?.map { dto ->
+                    RecordItem(
+                        date = dto.createdAt.toKoreanDateOrFallback(),
+                        title = dto.emotion.toTitle(),
+                        mood = dto.emotion.toChip(),
+                        content = dto.content,
+                        imageRes = R.drawable.dummy1 //일단은 서버에서 안내오고 있어서 밴드 붙였습니다
+                    )
+                }
+
+                _items.value = if (res.isSuccess && mapped != null) mapped else emptyList()
+            }.onFailure { e ->
+                e.printStackTrace()
+                _items.value = emptyList()
+            }
+
+        }
+    }
+
+    fun createMoment(
+        userId: Long,
+        petId: Long,
+        emotion: EmotionDto,
+        content: String,
+        imageUris: List<Uri>,
+        contentResolver: android.content.ContentResolver,
+        onSuccess: () -> Unit,
+        onFail: (Throwable) -> Unit
+    ) {
+        viewModelScope.launch {
+            runCatching {
+                momentRepository.createMomentWithImages(
+                    userId = userId,
+                    petId = petId,
+                    emotion = emotion,
+                    content = content,
+                    imageUris = imageUris,
+                    contentResolver = contentResolver
+                )
+            }.onSuccess { res ->
+                if (res.isSuccess) onSuccess() else onFail(IllegalStateException(res.message))
+            }.onFailure { e ->
+                onFail(e)
+            }
+        }
+    }
+
+}
+
+private fun String.toKoreanDateOrFallback(): String {
+    return runCatching {
+        val datePart = this.substring(0, 10) // yyyy-MM-dd
+        val (y, m, d) = datePart.split("-")
+        "$y.$m.$d"
+    }.getOrDefault(this)
+}
+
+private fun EmotionDto.toTitle(): String = when (this) {
+    EmotionDto.HAPPINESS -> "즐거운 날"
+    EmotionDto.SADNESS -> "슬픈 날"
+    EmotionDto.NEUTRAL -> "보통인 날"
+}
+
+private fun EmotionDto.toChip(): String = when (this) {
+    EmotionDto.HAPPINESS -> "즐거움"
+    EmotionDto.SADNESS -> "슬픔"
+    EmotionDto.NEUTRAL -> "보통"
+}
+

--- a/app/src/main/java/com/example/momenty/domain/record/detail/MomentDetailFragment.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/detail/MomentDetailFragment.kt
@@ -1,0 +1,91 @@
+package com.example.momenty.domain.record.detail
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.example.momenty.R
+import com.example.momenty.databinding.FragmentMomentDetailBinding
+import com.google.android.material.tabs.TabLayoutMediator
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class MomentDetailFragment : Fragment(R.layout.fragment_moment_detail) {
+
+    private lateinit var binding: FragmentMomentDetailBinding
+    private val viewModel: MomentDetailViewModel by viewModels()
+
+
+    private val args: MomentDetailFragmentArgs by navArgs()
+
+    private val pagerAdapter = MomentPhotoPagerAdapter()
+    private var tabMediator: TabLayoutMediator? = null
+
+
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding = FragmentMomentDetailBinding.bind(view)
+
+
+
+
+        // 상단 inset
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            val top = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+            binding.headerContainer.updatePadding(top = top)
+            insets
+        }
+        ViewCompat.requestApplyInsets(binding.root)
+
+        binding.ivBack.setOnClickListener { findNavController().popBackStack() }
+
+        binding.photoPager.adapter = pagerAdapter
+
+
+        viewModel.load(
+            userId = args.userId,
+            petId = args.petId,
+            momentId = args.momentId,
+            createdAt = args.createdAt
+        )
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.ui.collect { ui ->
+                if (ui == null) return@collect
+
+                binding.tvDate.text = ui.dateText
+                binding.tvMoodChip.text = ui.moodChipText
+                binding.tvTitleBold.text = ui.titleText
+                binding.tvBody.text = ui.bodyText
+
+                pagerAdapter.submitList(ui.imageUrls)
+                setupDots(ui.imageUrls.size)
+            }
+        }
+    }
+
+    private fun setupDots(count: Int) {
+        binding.dotsIndicator.visibility = if (count >= 2) View.VISIBLE else View.GONE
+        tabMediator?.detach()
+        tabMediator = null
+
+        if (count >= 2) {
+            tabMediator = TabLayoutMediator(binding.dotsIndicator, binding.photoPager) { _, _ -> }
+            tabMediator?.attach()
+        }
+    }
+
+    override fun onDestroyView() {
+        tabMediator?.detach()
+        tabMediator = null
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/com/example/momenty/domain/record/detail/MomentDetailUiModel.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/detail/MomentDetailUiModel.kt
@@ -1,0 +1,13 @@
+package com.example.momenty.domain.record.detail
+
+import com.example.momenty.data.remote.moment.EmotionDto
+
+data class MomentDetailUiModel(
+    val imageUrls: List<String>,
+    val dateText: String,
+    val moodChipText: String,
+    val moodTitleText: String,
+    val titleText: String,
+    val bodyText: String,
+    val emotion: EmotionDto
+)

--- a/app/src/main/java/com/example/momenty/domain/record/detail/MomentDetailViewModel.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/detail/MomentDetailViewModel.kt
@@ -1,0 +1,77 @@
+package com.example.momenty.domain.record.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.momenty.data.remote.moment.EmotionDto
+import com.example.momenty.data.repository.MomentRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import com.example.momenty.global.util.toKoreanDateOrFallback
+
+
+@HiltViewModel
+class MomentDetailViewModel @Inject constructor(
+    private val momentRepository: MomentRepository
+) : ViewModel() {
+
+    private val _ui = MutableStateFlow<MomentDetailUiModel?>(null)
+    val ui: StateFlow<MomentDetailUiModel?> = _ui
+
+    fun load(userId: Long, petId: Long, momentId: Long, createdAt: String) {
+        viewModelScope.launch {
+            runCatching {
+                momentRepository.getMomentDetail(userId, petId, momentId)
+            }.onSuccess { res ->
+                if (!res.isSuccess || res.result == null) {
+                    _ui.value = null
+                    return@onSuccess
+                }
+
+                val dto = res.result
+                val content = dto.content.orEmpty()
+
+                val (title, body) = splitTitleBody(content)
+
+
+                val imageUrls = if (dto.images.isNotEmpty()) {
+                    dto.images.mapIndexed { idx, _ -> "https://picsum.photos/600/600?random=$idx" }
+                } else emptyList()
+
+                _ui.value = MomentDetailUiModel(
+                    imageUrls = imageUrls,
+                    dateText = createdAt.toKoreanDateOrFallback(),
+                    moodChipText = dto.emotion.toChip(),
+                    moodTitleText = dto.emotion.toTitle(),
+                    titleText = title,
+                    bodyText = body,
+                    emotion = dto.emotion
+                )
+            }.onFailure {
+                it.printStackTrace()
+                _ui.value = null
+            }
+        }
+    }
+
+    private fun splitTitleBody(content: String): Pair<String, String> {
+        val lines = content.split("\n")
+        val title = lines.firstOrNull()?.trim().orEmpty()
+        val body = lines.drop(1).joinToString("\n").trim()
+        return if (title.isBlank()) "제목 없음" to content else title to body
+    }
+}
+
+private fun EmotionDto.toTitle(): String = when (this) {
+    EmotionDto.HAPPINESS -> "즐거운 날"
+    EmotionDto.SADNESS -> "슬픈 날"
+    EmotionDto.NEUTRAL -> "보통인 날"
+}
+
+private fun EmotionDto.toChip(): String = when (this) {
+    EmotionDto.HAPPINESS -> "즐거움"
+    EmotionDto.SADNESS -> "슬픔"
+    EmotionDto.NEUTRAL -> "보통"
+}

--- a/app/src/main/java/com/example/momenty/domain/record/detail/MomentPhotoPagerAdapter.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/detail/MomentPhotoPagerAdapter.kt
@@ -1,0 +1,40 @@
+package com.example.momenty.domain.record.detail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.example.momenty.databinding.ItemMomentDetailPhotoBinding
+
+class MomentPhotoPagerAdapter : RecyclerView.Adapter<MomentPhotoPagerAdapter.VH>() {
+
+    private val items = mutableListOf<String>()
+
+    fun submitList(list: List<String>) {
+        items.clear()
+        items.addAll(list)
+        notifyDataSetChanged()
+    }
+
+    inner class VH(private val binding: ItemMomentDetailPhotoBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(url: String) {
+            Glide.with(binding.ivPhoto)
+                .load(url)
+                .centerCrop()
+                .into(binding.ivPhoto)
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val binding = ItemMomentDetailPhotoBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return VH(binding)
+    }
+
+    override fun onBindViewHolder(holder: VH, position: Int) = holder.bind(items[position])
+    override fun getItemCount(): Int = items.size
+}

--- a/app/src/main/java/com/example/momenty/domain/record/write/RecordItem.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/write/RecordItem.kt
@@ -1,10 +1,11 @@
 package com.example.momenty.domain.record.write
 
 data class RecordItem(
+    val momentId: Long,
+    val createdAtRaw: String,
     val date: String,
     val title: String,
     val mood: String,
     val content: String,
     val imageRes: Int
 )
-

--- a/app/src/main/java/com/example/momenty/domain/record/write/RecordWriteFragment.kt
+++ b/app/src/main/java/com/example/momenty/domain/record/write/RecordWriteFragment.kt
@@ -10,13 +10,18 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.momenty.R
+import com.example.momenty.data.remote.moment.EmotionDto
 import com.example.momenty.databinding.FragmentRecordWriteBinding
+import com.example.momenty.domain.record.RecordViewModel
 import com.google.android.material.tabs.TabLayoutMediator
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class RecordWriteFragment : Fragment(R.layout.fragment_record_write) {
 
     private lateinit var binding: FragmentRecordWriteBinding
@@ -30,7 +35,18 @@ class RecordWriteFragment : Fragment(R.layout.fragment_record_write) {
     private val MAX_COUNT = 5
 
 
-    private enum class Mood { GOOD, SOSO, BAD }
+    private val viewModel: RecordViewModel by viewModels()
+
+    private enum class Mood {
+        GOOD, SOSO, BAD;
+
+        fun toEmotionDto(): EmotionDto = when (this) {
+            GOOD -> EmotionDto.HAPPINESS
+            SOSO -> EmotionDto.NEUTRAL
+            BAD -> EmotionDto.SADNESS
+        }
+    }
+
     private var selectedMood: Mood = Mood.SOSO
 
     private val pickImages =
@@ -91,9 +107,30 @@ class RecordWriteFragment : Fragment(R.layout.fragment_record_write) {
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnCancel.setOnClickListener { findNavController().popBackStack() }
-        binding.btnSave.setOnClickListener {
 
-            findNavController().navigate(R.id.recordFragment)
+
+        binding.btnSave.setOnClickListener {
+            val userId = 1L
+            val petId = 1L
+
+            val emotion = selectedMood.toEmotionDto()
+            val content = binding.etContent.text?.toString().orEmpty()
+
+            viewModel.createMoment(
+                userId = userId,
+                petId = petId,
+                emotion = emotion,
+                content = content,
+                imageUris = photos.toList(),
+                contentResolver = requireContext().contentResolver,
+                onSuccess = {
+                    findNavController().navigate(R.id.recordFragment)
+                },
+                onFail = { e ->
+                    e.printStackTrace()
+
+                }
+            )
         }
     }
 
@@ -193,3 +230,4 @@ class RecordWriteFragment : Fragment(R.layout.fragment_record_write) {
         }
     }
 }
+

--- a/app/src/main/java/com/example/momenty/global/mock/MockApiInterceptor.kt
+++ b/app/src/main/java/com/example/momenty/global/mock/MockApiInterceptor.kt
@@ -107,6 +107,12 @@ class MockApiInterceptor : Interceptor {
                 mockCreateMomentPresignedUrls()
             }
 
+            path.matches(Regex(".*/api/moments/users/\\d+/pets/\\d+/\\d+")) && method == "GET" -> {
+                Log.d("MockApi", "HIT momentDetail")
+                mockGetMomentDetail()
+            }
+
+
 
 
 
@@ -331,6 +337,30 @@ class MockApiInterceptor : Interceptor {
               "hasNext": false,
               "hasPrevious": false
             }
+          }
+        }
+        """.trimIndent()
+        )
+    }
+
+
+    private fun mockGetMomentDetail(): MockResponse {
+        val itemsJson = (1..3).joinToString(",") {
+            val key = "moments/${UUID.randomUUID()}.jpg"
+            """{ "imageKey": "$key" }"""
+        }
+        return MockResponse(
+            code = 200,
+            message = "OK",
+            body = """
+        {
+          "isSuccess": true,
+          "code": "MOMENT_DETAIL_SUCCESS",
+          "message": "모먼트 상세 조회 성공",
+          "result": {
+            "images": [ $itemsJson ],
+            "emotion": "HAPPINESS",
+            "content": "푸들이의 특별한 하루\n오늘은 정말 특별했어요. 산책도 하고 간식도 먹고..."
           }
         }
         """.trimIndent()

--- a/app/src/main/java/com/example/momenty/global/mock/MockApiInterceptor.kt
+++ b/app/src/main/java/com/example/momenty/global/mock/MockApiInterceptor.kt
@@ -1,11 +1,13 @@
 package com.example.momenty.global.mock
 
+import android.util.Log
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import java.util.UUID
+
 
 /**
  * Mock API Interceptor
@@ -37,6 +39,9 @@ class MockApiInterceptor : Interceptor {
         val request = chain.request()
         val path = request.url.encodedPath
         val method = request.method
+
+        android.util.Log.d("MockApi", "REQ: $method $path (mock=$isMockEnabled)")
+
 
         // API 경로별 Mock 응답 생성
         val mockResponse = when {
@@ -81,15 +86,29 @@ class MockApiInterceptor : Interceptor {
             }
 
             // ==================== 모먼트 API ====================
-            path.endsWith("/api/moments") && method == "GET" -> {
-                mockGetMoments()
+
+
+            // /api/moments/users/{userId}/pets/{petId}
+            path.matches(Regex(".*/api/moments/users/\\d+/pets/\\d+")) && method == "GET" -> {
+                Log.d("MockApi", "HIT momentsByPet")
+                mockGetMomentsByPet()
             }
-            path.endsWith("/api/moments") && method == "POST" -> {
-                mockCreateMoment()
+
+
+            path.matches(Regex("/api/moments/users/\\d+/pets/\\d+")) && method == "POST" -> {
+                Log.d("MockApi", "HIT createMomentByPet")
+                mockCreateMomentByPet()
             }
-            path.matches(Regex(".*/api/moments/\\d+")) && method == "GET" -> {
-                mockGetMomentDetail()
+
+
+
+            path.endsWith("/api/moments/image") && method == "POST" -> {
+                android.util.Log.d("MockApi", "HIT momentsPresigned")
+                mockCreateMomentPresignedUrls()
             }
+
+
+
 
             // ==================== 챗봇 API ====================
             path.endsWith("/api/chatbot/messages") && method == "POST" -> {
@@ -227,6 +246,98 @@ class MockApiInterceptor : Interceptor {
             """.trimIndent()
         )
     }
+
+
+    private fun mockCreateMomentPresignedUrls(): MockResponse {
+        val itemsJson = (1..5).joinToString(",") {
+            val key = "moments/${UUID.randomUUID()}.jpg"
+            val url = "https://mock-s3-bucket.s3.amazonaws.com/$key?signature=mock"
+            """{ "key": "$key", "url": "$url" }"""
+        }
+
+        return MockResponse(
+            code = 201,
+            message = "Created",
+            body = """
+        {
+          "isSuccess": true,
+          "code": "PRESIGNED_URL_CREATED",
+          "message": "Presigned URL 발급 성공",
+          "result": [
+            $itemsJson
+          ]
+        }
+        """.trimIndent()
+        )
+    }
+
+
+
+    private fun mockCreateMomentByPet(): MockResponse {
+        return MockResponse(
+
+            code = 201,
+            message = "Created",
+            body = """
+            {
+              "isSuccess": true,
+              "code": "MOMENT_CREATED",
+              "message": "모먼트 생성 성공",
+              "result": "moment_${UUID.randomUUID()}"
+            }
+        """.trimIndent()
+        )
+    }
+
+
+    private fun mockGetMomentsByPet(): MockResponse {
+        return MockResponse(
+            code = 200,
+            message = "OK",
+            body = """
+        {
+          "isSuccess": true,
+          "code": "MOMENTS_SUCCESS",
+          "message": "모먼트 조회 성공",
+          "result": {
+            "moments": [
+              {
+                "momentId": 1,
+                "emotion": "HAPPINESS",
+                "createdAt": "2026-02-10T14:30:00",
+                "content": "오늘 산책하다가 친구 강아지를 만났어요!",
+                "imageUrl": "https://picsum.photos/300/300"
+              },
+              {
+                "momentId": 2,
+                "emotion": "NEUTRAL",
+                "createdAt": "2026-02-09T18:20:00",
+                "content": "집에서 푹 쉬는 하루.",
+                "imageUrl": "https://picsum.photos/300/300"
+              },
+              {
+                "momentId": 3,
+                "emotion": "SADNESS",
+                "createdAt": "2026-02-08T09:15:00",
+                "content": "병원 다녀오느라 조금 힘들었어요.",
+                "imageUrl": "https://picsum.photos/300/300"
+              }
+            ],
+            "pageInfo": {
+              "page": 0,
+              "size": 10,
+              "totalPages": 1,
+              "totalElements": 3,
+              "hasNext": false,
+              "hasPrevious": false
+            }
+          }
+        }
+        """.trimIndent()
+        )
+    }
+
+
 
     /**
      * Presigned URL 발급 Mock
@@ -375,88 +486,7 @@ class MockApiInterceptor : Interceptor {
         )
     }
 
-    /**
-     * 모먼트 리스트 조회 Mock
-     */
-    private fun mockGetMoments(): MockResponse {
-        return MockResponse(
-            code = 200,
-            message = "OK",
-            body = """
-                {
-                    "isSuccess": true,
-                    "code": "MOMENTS_SUCCESS",
-                    "message": "모먼트 조회 성공",
-                    "result": {
-                        "moments": [
-                            {
-                                "momentId": "m_1",
-                                "title": "행복한 산책",
-                                "emotion": "HAPPY",
-                                "imageUrl": "https://example.com/moment1.jpg",
-                                "date": "2026-02-10"
-                            },
-                            {
-                                "momentId": "m_2",
-                                "title": "병원 다녀옴",
-                                "emotion": "WORRIED",
-                                "imageUrl": "https://example.com/moment2.jpg",
-                                "date": "2026-02-09"
-                            }
-                        ]
-                    }
-                }
-            """.trimIndent()
-        )
-    }
 
-    /**
-     * 모먼트 생성 Mock
-     */
-    private fun mockCreateMoment(): MockResponse {
-        return MockResponse(
-            code = 201,
-            message = "Created",
-            body = """
-                {
-                    "isSuccess": true,
-                    "code": "MOMENT_CREATED",
-                    "message": "모먼트 생성 성공",
-                    "result": {
-                        "momentId": "m_${UUID.randomUUID()}",
-                        "title": "새로운 모먼트",
-                        "emotion": "HAPPY"
-                    }
-                }
-            """.trimIndent()
-        )
-    }
-
-    /**
-     * 모먼트 상세 조회 Mock
-     */
-    private fun mockGetMomentDetail(): MockResponse {
-        return MockResponse(
-            code = 200,
-            message = "OK",
-            body = """
-                {
-                    "isSuccess": true,
-                    "code": "MOMENT_DETAIL_SUCCESS",
-                    "message": "모먼트 상세 조회 성공",
-                    "result": {
-                        "momentId": "m_1",
-                        "title": "행복한 산책",
-                        "content": "오늘 공원에서 다른 강아지 친구들을 많이 만났어요!",
-                        "emotion": "HAPPY",
-                        "imageUrl": "https://example.com/moment1.jpg",
-                        "date": "2026-02-10",
-                        "createdAt": "2026-02-10T14:30:00"
-                    }
-                }
-            """.trimIndent()
-        )
-    }
 
     /**
      * 챗봇 메시지 전송 Mock

--- a/app/src/main/java/com/example/momenty/global/security/AuthIntercepter.kt
+++ b/app/src/main/java/com/example/momenty/global/security/AuthIntercepter.kt
@@ -12,6 +12,15 @@ class AuthInterceptor @Inject constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
+
+        val url = originalRequest.url
+        val host = url.host
+
+
+        if (host.contains("amazonaws.com")) {
+            return chain.proceed(originalRequest)
+        }
+
         // 토큰이 필요 없는 엔드포인트 (로그인, 회원가입 등)
         val noAuthPaths = listOf("/auth/login", "/auth/signup", "/auth/refresh")
         val isNoAuthPath = noAuthPaths.any { originalRequest.url.encodedPath.contains(it) }

--- a/app/src/main/java/com/example/momenty/global/util/DateExt.kt
+++ b/app/src/main/java/com/example/momenty/global/util/DateExt.kt
@@ -1,0 +1,31 @@
+package com.example.momenty.global.util
+
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+fun String.toKoreanDateOrFallback(): String {
+    val seoulTz = TimeZone.getTimeZone("Asia/Seoul")
+
+
+    val inputPatterns = listOf(
+        "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", // 2026-02-17T01:23:45.123+09:00
+        "yyyy-MM-dd'T'HH:mm:ssXXX",     // 2026-02-17T01:23:45+09:00
+        "yyyy-MM-dd'T'HH:mm:ss.SSSX",   // 2026-02-17T01:23:45.123Z or +0900
+        "yyyy-MM-dd'T'HH:mm:ssX"        // 2026-02-17T01:23:45Z or +0900
+    )
+
+    val date = inputPatterns.firstNotNullOfOrNull { pattern ->
+        runCatching {
+            SimpleDateFormat(pattern, Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+                isLenient = false
+            }.parse(this)
+        }.getOrNull()
+    } ?: return this
+
+    val out = SimpleDateFormat("yyyy.MM.dd (E) a h:mm", Locale.KOREAN).apply {
+        timeZone = seoulTz
+    }
+    return out.format(date)
+}

--- a/app/src/main/res/layout/fragment_moment_detail.xml
+++ b/app/src/main/res/layout/fragment_moment_detail.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/primary_sub">
+
+
+    <View
+        android:id="@+id/headerWhiteBg"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@color/white"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/headerContainer"/>
+
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/headerContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:minHeight="56dp"
+        android:background="@color/white"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageView
+            android:id="@+id/ivBack"
+            android:layout_width="30dp"
+            android:layout_height="35dp"
+            android:src="@drawable/img_arrow_left"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <TextView
+            android:id="@+id/tvHeaderTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="모먼트 기록"
+            android:textColor="@color/body_1"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/headerDivider"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:background="@color/caption_2"
+        app:layout_constraintTop_toBottomOf="@id/headerContainer"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        android:overScrollMode="never"
+        android:clipToPadding="false"
+        app:layout_constraintTop_toBottomOf="@id/headerDivider"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="14dp"
+            android:paddingBottom="20dp">
+
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/photoMetaCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="0dp"
+                app:cardBackgroundColor="@color/white">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="12dp">
+
+
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/photoCard"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:cardCornerRadius="12dp"
+                        app:cardElevation="0dp">
+
+
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
+
+                            <FrameLayout
+                                android:id="@+id/photoFrame"
+                                android:layout_width="0dp"
+                                android:layout_height="0dp"
+                                app:layout_constraintTop_toTopOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintDimensionRatio="16:9">
+
+                                <androidx.viewpager2.widget.ViewPager2
+                                    android:id="@+id/photoPager"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="match_parent"/>
+
+                                <com.google.android.material.tabs.TabLayout
+                                    android:id="@+id/dotsIndicator"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="16dp"
+                                    android:layout_gravity="bottom|center_horizontal"
+                                    android:layout_marginBottom="10dp"
+                                    android:background="@android:color/transparent"
+                                    app:tabMode="scrollable"
+                                    app:tabGravity="center"
+                                    app:tabIndicator="@null"
+                                    app:tabIndicatorHeight="0dp"
+                                    app:tabRippleColor="@android:color/transparent"
+                                    app:tabMinWidth="0dp"
+                                    app:tabPadding="0dp"
+                                    app:tabPaddingStart="8dp"
+                                    app:tabPaddingEnd="8dp"
+                                    app:tabBackground="@drawable/tab_dot_record_selector"/>
+                            </FrameLayout>
+
+                        </androidx.constraintlayout.widget.ConstraintLayout>
+                    </androidx.cardview.widget.CardView>
+
+
+                    <LinearLayout
+                        android:id="@+id/metaContainer"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:paddingTop="12dp"
+                        android:paddingBottom="4dp"
+                        android:paddingStart="4dp"
+                        android:paddingEnd="4dp">
+
+                        <TextView
+                            android:id="@+id/tvDate"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textStyle="bold"
+                            android:textSize="14sp"
+                            android:textColor="@color/body_1"/>
+
+                        <TextView
+                            android:id="@+id/tvMoodChip"
+                            android:layout_width="wrap_content"
+                            android:layout_height="22dp"
+                            android:layout_marginTop="8dp"
+                            android:gravity="center"
+                            android:paddingHorizontal="10dp"
+                            android:textSize="12sp"
+                            android:textColor="@color/primary"
+                            android:background="@drawable/bg_mood_chip"/>
+
+
+                    </LinearLayout>
+
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
+            <!-- ✅ Card 2: 제목/본문만 -->
+            <androidx.cardview.widget.CardView
+                android:id="@+id/contentCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="0dp"
+                app:cardBackgroundColor="@color/white">
+
+                <LinearLayout
+                    android:id="@+id/contentContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:id="@+id/tvTitleBold"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textStyle="bold"
+                        android:textSize="14sp"
+                        android:textColor="@color/body_1"/>
+
+                    <TextView
+                        android:id="@+id/tvBody"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:textSize="13sp"
+                        android:textColor="@color/caption_1"/>
+                </LinearLayout>
+
+            </androidx.cardview.widget.CardView>
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_moment_detail_photo.xml
+++ b/app/src/main/res/layout/item_moment_detail_photo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/ivPhoto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop"
+        android:contentDescription="@string/app_name"/>
+</FrameLayout>

--- a/app/src/main/res/navigation/record_graph.xml
+++ b/app/src/main/res/navigation/record_graph.xml
@@ -10,10 +10,6 @@
         android:name="com.example.momenty.domain.record.RecordFragment"
         tools:layout="@layout/fragment_record">
 
-        <argument
-            android:name="hideBottomNav"
-            app:argType="boolean"
-            android:defaultValue="true" />
 
         <action
             android:id="@+id/action_record_to_write"

--- a/app/src/main/res/navigation/record_graph.xml
+++ b/app/src/main/res/navigation/record_graph.xml
@@ -22,6 +22,11 @@
         <action
             android:id="@+id/action_record_to_recordStats"
             app:destination="@id/recordStatsFragment" />
+
+        <action
+            android:id="@+id/action_record_to_momentDetail"
+            app:destination="@id/momentDetailFragment" />
+
     </fragment>
 
     <fragment
@@ -32,6 +37,8 @@
             android:name="hideBottomNav"
             app:argType="boolean"
             android:defaultValue="true" />
+
+
     </fragment>
 
     <fragment
@@ -72,4 +79,27 @@
             android:defaultValue="true" />
     </fragment>
 
+    <fragment
+        android:id="@+id/momentDetailFragment"
+        android:name="com.example.momenty.domain.record.detail.MomentDetailFragment"
+        android:label="MomentDetailFragment"
+        tools:layout="@layout/fragment_moment_detail">
+
+        <argument
+            android:name="userId"
+            app:argType="long" />
+
+        <argument
+            android:name="petId"
+            app:argType="long" />
+
+        <argument
+            android:name="momentId"
+            app:argType="long" />
+
+        <argument
+            android:name="createdAt"
+            app:argType="string" />
+
+    </fragment>
 </navigation>


### PR DESCRIPTION
## #️⃣연관된 이슈

> 관련된 이슈 번호를 적어주세요.
 - Closes #52 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 목록 조희 api, 2. 작성 api, 3. 이미지 api, 4. 상세조회 api연결 했습니다.
2. 추가로 오늘 나온 UI도 같이 작업했습니다. (모먼트 상세 조희 UI)

MockApiInterceptor를 활용하여 Moment API 연동 흐름을 사전 검증, 실제 서버 연동 전, 상세 조회/목록 조회 정상 동작 확인 완료했습니다.

다만, 현재 GET
 [/api/moments/users/{userId}/pets/{petId}에서 url키가 안내려오고 있어서 더미로 테스트했습니다. 
GET
 [/api/moments/users/{userId}/pets/{petId}/{momentId} 에서도 날짜가 안내려오고 있어서 따로 테스트 했습니다.



## #️⃣스크린샷 (선택)

> UI 변경 사항이 있다면 스크린샷을 첨부해주세요.


| 모먼트 목록 조회 | 모먼트 작성 | 모먼트 상세조회 |
|---|---|---|
|<img width="363" height="782" alt="image" src="https://github.com/user-attachments/assets/72dec046-6f63-40bd-96e0-9c7a119c8d5d" />|<img width="376" height="785" alt="image" src="https://github.com/user-attachments/assets/70e61f68-6d27-4e13-a76a-594000183ea4" />|<img width="388" height="793" alt="image" src="https://github.com/user-attachments/assets/bf0030ef-adbe-4509-b75d-4d564d8beb82" />|



```
REQ: GET /api/moments/users/1/pets/1 (mock=true)
2026-02-17 06:09:41.444 10806-10949 MockApi                 com.example.momenty                  D  HIT momentsByPet
```

```
hide(ime(), fromIme=false)
2026-02-17 06:10:22.544 10806-10806 InsetsController        com.example.momenty                  D  Setting requestedVisibleTypes to -9 (was -1)
```
```

REQ: GET /api/moments/users/1/pets/1/1 (mock=true)
2026-02-17 06:11:04.034 10806-10949 MockApi                 com.example.momenty                  D  HIT momentDetail
```